### PR TITLE
fix: capabilities sintaxis based on libcap version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -79,7 +79,7 @@
     - ansible_os_family | lower == "debian"
     - restic_user != 'root'
 
-- name: Set proper capabilities for restic binary
+- name: Set proper capabilities for restic binary when libcap <= 2.40
   capabilities:
     path: '{{ restic_install_path }}/restic'
     capability: cap_dac_read_search+ep
@@ -87,3 +87,11 @@
   when:
     - restic_user != 'root'
     - not ansible_check_mode
+    - libcap_version < '2.41'
+
+- name: Set proper capabilities for restic binary when libcap > 2.40
+  command: setcap cap_dac_read_search=ep {{ restic_install_path }}/restic
+  when:
+    - restic_user != 'root'
+    - not ansible_check_mode
+    - libcap_version >= '2.41'

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -33,3 +33,16 @@
     restic_checksum: "{{ item.split(' ')[0] }}"
   with_items: "{{ (_checksums.content | b64decode).split('\n') }}"
   when: "('restic_' + restic_version + '_linux_' + go_arch + '.bz2') in item"
+
+- name: Execute command to get libcap version
+  command: "dpkg-query --showformat='${Version}' --show libcap2"
+  register: libcap_version_full
+  changed_when: false
+
+- name: Filter libcap version
+  set_fact:
+    libcap_version: "{{ libcap_version_full.stdout | regex_replace('^(\\d+:)?(\\d+\\.\\d+).*$', '\\2') }}"
+
+- name: Display libcap version
+  debug:
+    var: libcap_version


### PR DESCRIPTION
Workaround for libcap sintax changes: https://github.com/ansible/ansible/issues/72662