### PR TITLE
fix: no log restic values

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,5 +24,6 @@
 - include: configure_repos.yml
   with_items: '{{ restic_repos }}'
   become: true
+  no_log: true
   tags:
     - restic_configure


### PR DESCRIPTION
As we're start to using CD, we're double-checking the output of the ansible roles.

This one was leaking the restic parameters on the log.

```
TASK [coopdevs.ansible_restic : include] ***************************************
included: /opt/odoo-provisioning/roles/coopdevs.ansible_restic/tasks/configure_repos.yml for odoo-test-14.coopdevs.org => (item={'name': '*****************', 'url': 'b2:*****************', 'password': '*****************', 'remote_credentials': {'b2_account_id': '*****************', 'b2_account_key': '*****************'}, 'jobs': [{'command': '/opt/backup/bin/backup.sh', 'at': '45 03 * * *', 'user': 'backups'}], 'check': False})
TASK [coopdevs.ansible_restic : Deploy cron script] ****************************
ok: [odoo-test-14.coopdevs.org]
```